### PR TITLE
fix issue #20

### DIFF
--- a/unity/Cube/Assets/Scripts/Editor/XCodePostBuild.cs
+++ b/unity/Cube/Assets/Scripts/Editor/XCodePostBuild.cs
@@ -68,6 +68,7 @@ public static class XcodePostBuild
     private static string ClassesProjectPath =  "UnityExport/Classes";
     private static string LibrariesProjectPath = "UnityExport/Libraries";
 	private static string DataProjectPath =  "UnityExport/Data";
+    private static string VuforiaDataProjectPath =  "UnityExport/Vuforia";
 
     /// <summary>
     /// Path, relative to the root directory of the Xcode project, to put information about generated Unity output.
@@ -145,11 +146,18 @@ public static class XcodePostBuild
             Path.Combine(XcodeProjectRoot, LibrariesProjectPath),
             LibrariesProjectPath);
 
-        // Add UnityExport/Data
 		var targetGuid = pbx.TargetGuidByName(XcodeProjectName);
-		var fileGuid = pbx.AddFolderReference(Path.Combine(pathToBuiltProject, "Data"), DataProjectPath);
-		pbx.AddFileToBuild(targetGuid, fileGuid);
 
+        // Add UnityExport/Data
+		var fileGuid = pbx.AddFolderReference(Path.Combine(pathToBuiltProject, "Data"), DataProjectPath);
+        pbx.AddFileToBuild(targetGuid, fileGuid);
+
+        // Add UnityExport/Vuforia dir(if exists)
+        var vuforiaDataDir = Path.Combine(pathToBuiltProject, "Data/Raw/Vuforia");
+        if (Directory.Exists(vuforiaDataDir)){ //check if vuforia exists in the data folder.
+            pbx.AddFileToBuild(targetGuid, pbx.AddFolderReference(vuforiaDataDir, VuforiaDataProjectPath));
+        }
+        
         pbx.WriteToFile(pbxPath);
     }
 


### PR DESCRIPTION
As mentioned on issue f111fei/react-native-unity-view#20, when we try to use a project with **Vuforia** on **iOS**, the **Vuforia Dataset** isn't loaded correctly:

> Dataset Foo could not be loaded and cannot be activated.

Because of this, the recognition doesn't work.

We can fix it simple dragging the **Data/Raw/Vuforia** folder from the **UnityExport** directory to the UnityExport group in Xcode, selecting **Create folder references**.

I've changed the **XCodePostBuild.cs** file to check if the **Vuforia** folder exists in the Data/Raw directory, and if it exists, we create a reference of it on UnityExport folder. 

This fixes the issue. 