### PR TITLE
Changes to work with 2019.3.0f3

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">rnunitydemo</string>
+    <string name="game_view_content_description"></string>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "27.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 19
         compileSdkVersion = 27
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -3,6 +3,6 @@ include ':react-native-unity-view'
 project(':react-native-unity-view').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-unity-view/android')
 
 include ":UnityExport"
-project(":UnityExport").projectDir = file("./UnityExport")
+project(":UnityExport").projectDir = file("./UnityExport/unityLibrary")
 
 include ':app'

--- a/unity/Cube/Assets/Scripts/Editor/Build.cs
+++ b/unity/Cube/Assets/Scripts/Editor/Build.cs
@@ -12,8 +12,6 @@ public class Build : MonoBehaviour
 {
     static readonly string ProjectPath = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
 
-    static readonly string apkPath = Path.Combine(ProjectPath, "Builds/" + Application.productName + ".apk");
-
     [MenuItem("Build/Export for Android %&a", false, 1)]
     public static void DoBuildAndroid()
     {

--- a/unity/Cube/Assets/Scripts/Editor/Build.cs
+++ b/unity/Cube/Assets/Scripts/Editor/Build.cs
@@ -38,9 +38,7 @@ public class Build : MonoBehaviour
         // Modify build.gradle
 		var build_file = Path.Combine(exportPath, "unityLibrary/build.gradle");
 		var build_text = File.ReadAllText(build_file);
-		build_text = build_text.Replace("com.android.application", "com.android.library");
-        build_text = build_text.Replace("implementation fileTree(dir: 'libs', include: ['*.jar'])", "api fileTree(include: ['*.jar'], dir: 'libs')");
-		build_text = Regex.Replace(build_text, @"\n.*applicationId '.+'.*\n", "\n");
+		build_text = build_text.Replace("implementation fileTree(dir: 'libs', include: ['*.jar'])", "api fileTree(dir: 'libs', include: ['*.jar'])");
 		File.WriteAllText(build_file, build_text);
 
         // Modify AndroidManifest.xml

--- a/unity/Cube/Assets/Scripts/Editor/Build.cs
+++ b/unity/Cube/Assets/Scripts/Editor/Build.cs
@@ -36,10 +36,10 @@ public class Build : MonoBehaviour
             throw new Exception("Build failed");
 
         // Modify build.gradle
-		var build_file = Path.Combine(exportPath, "unityLibrary/build.gradle");
-		var build_text = File.ReadAllText(build_file);
-		build_text = build_text.Replace("implementation fileTree(dir: 'libs', include: ['*.jar'])", "api fileTree(dir: 'libs', include: ['*.jar'])");
-		File.WriteAllText(build_file, build_text);
+        var build_file = Path.Combine(exportPath, "unityLibrary/build.gradle");
+        var build_text = File.ReadAllText(build_file);
+        build_text = build_text.Replace("implementation fileTree(dir: 'libs', include: ['*.jar'])", "api fileTree(dir: 'libs', include: ['*.jar'])");
+        File.WriteAllText(build_file, build_text);
 
         // Modify AndroidManifest.xml
         var manifest_file = Path.Combine(exportPath, "unityLibrary/src/main/AndroidManifest.xml");
@@ -69,7 +69,7 @@ public class Build : MonoBehaviour
         );
 
         if (report.summary.result != BuildResult.Succeeded)
-            throw new Exception("Build failed");   
+            throw new Exception("Build failed");
     }
 
     static string[] GetEnabledScenes()

--- a/unity/Cube/Assets/Scripts/Editor/Build.cs
+++ b/unity/Cube/Assets/Scripts/Editor/Build.cs
@@ -42,7 +42,6 @@ public class Build : MonoBehaviour
         // Modify AndroidManifest.xml
         var manifest_file = Path.Combine(exportPath, "unityLibrary/src/main/AndroidManifest.xml");
         var manifest_text = File.ReadAllText(manifest_file);
-        manifest_text = Regex.Replace(manifest_text, @"<application .*>", "<application>");
         Regex regex = new Regex(@"<activity.*>(\s|\S)+?</activity>", RegexOptions.Multiline);
         manifest_text = regex.Replace(manifest_text, "");
         File.WriteAllText(manifest_file, manifest_text);


### PR DESCRIPTION
Build was broken when using `2019.3.0f3`. Also, Android can directly export the same way iOS builds are exported. No need for copy.